### PR TITLE
[ESKL-84/cancel-overlay] - Page overlay when cancelling payment

### DIFF
--- a/2048/2048/src/main/java/com/appcoins/eskills2048/LaunchActivity.java
+++ b/2048/2048/src/main/java/com/appcoins/eskills2048/LaunchActivity.java
@@ -63,6 +63,7 @@ public class LaunchActivity extends AppCompatActivity {
   public void onBackPressed() {
     binding.startNewGameLayout.startNewGameCard.setVisibility(View.VISIBLE);
     binding.createTicketLayout.createTicketCard.setVisibility(View.GONE);
+    binding.canceledTicketLayout.canceledCard.setVisibility(View.GONE);
   }
 
   private void showCreateTicket(MatchDetails.Environment environment) {


### PR DESCRIPTION
When trying to cancel an E-skills payment, on the "We're sorry To See
You Go" Page, occurs a page overlay when the "Go back" button is
clicked.