### PR TITLE
[ESKL-130/show-opponent-status] - Shows a toast when opponent finishes

### DIFF
--- a/2048/2048/src/main/java/com/appcoins/eskills2048/MainActivity.java
+++ b/2048/2048/src/main/java/com/appcoins/eskills2048/MainActivity.java
@@ -6,7 +6,6 @@ import android.os.Bundle;
 import android.view.KeyEvent;
 import androidx.appcompat.app.AppCompatActivity;
 import com.appcoins.eskills2048.model.LocalGameStatus;
-import com.appcoins.eskills2048.model.User;
 import com.appcoins.eskills2048.model.UserDetailsHelper;
 import com.appcoins.eskills2048.usecase.GetRoomUseCase;
 import com.appcoins.eskills2048.usecase.NotifyOpponentFinishedUseCase;
@@ -48,7 +47,8 @@ import static com.appcoins.eskills2048.LaunchActivity.WALLET_ADDRESS;
     super.onCreate(savedInstanceState);
     view = new MainView(this,
         new MainGameViewModel(setScoreUseCase, setFinalScoreUseCase, buildViewModelData(),
-            getRoomUseCase, setGameStatusLocallyUseCase, new NotifyOpponentFinishedUseCase(opponent -> view.game.onOpponentFinished(opponent))),
+            getRoomUseCase, setGameStatusLocallyUseCase,
+            new NotifyOpponentFinishedUseCase(opponent -> view.game.onOpponentFinished(opponent))),
         userDetailsHelper, userDataStorage);
     setContentView(view);
   }
@@ -95,9 +95,5 @@ import static com.appcoins.eskills2048.LaunchActivity.WALLET_ADDRESS;
 
   @Override public void onBackPressed() {
     view.onBackPressed();
-  }
-
-  @Override public void onOpponentFinished(User opponent) {
-    view.game.onOpponentFinished(opponent);
   }
 }

--- a/2048/2048/src/main/java/com/appcoins/eskills2048/MainActivity.java
+++ b/2048/2048/src/main/java/com/appcoins/eskills2048/MainActivity.java
@@ -6,8 +6,10 @@ import android.os.Bundle;
 import android.view.KeyEvent;
 import androidx.appcompat.app.AppCompatActivity;
 import com.appcoins.eskills2048.model.LocalGameStatus;
+import com.appcoins.eskills2048.model.User;
 import com.appcoins.eskills2048.model.UserDetailsHelper;
 import com.appcoins.eskills2048.usecase.GetRoomUseCase;
+import com.appcoins.eskills2048.usecase.NotifyOpponentFinishedUseCase;
 import com.appcoins.eskills2048.usecase.SetFinalScoreUseCase;
 import com.appcoins.eskills2048.usecase.SetGameStatusLocallyUseCase;
 import com.appcoins.eskills2048.usecase.SetScoreUseCase;
@@ -22,7 +24,8 @@ import static com.appcoins.eskills2048.LaunchActivity.SESSION;
 import static com.appcoins.eskills2048.LaunchActivity.USER_ID;
 import static com.appcoins.eskills2048.LaunchActivity.WALLET_ADDRESS;
 
-@AndroidEntryPoint public class MainActivity extends AppCompatActivity {
+@AndroidEntryPoint public class MainActivity extends AppCompatActivity
+    implements OpponentStatusListener {
   private MainView view;
 
   @Inject UserDataStorage userDataStorage;
@@ -46,7 +49,8 @@ import static com.appcoins.eskills2048.LaunchActivity.WALLET_ADDRESS;
     super.onCreate(savedInstanceState);
     view = new MainView(this,
         new MainGameViewModel(setScoreUseCase, setFinalScoreUseCase, buildViewModelData(),
-            getRoomUseCase, setGameStatusLocallyUseCase), userDetailsHelper, userDataStorage);
+            getRoomUseCase, setGameStatusLocallyUseCase, new NotifyOpponentFinishedUseCase(this)),
+        userDetailsHelper, userDataStorage);
     setContentView(view);
   }
 
@@ -92,5 +96,9 @@ import static com.appcoins.eskills2048.LaunchActivity.WALLET_ADDRESS;
 
   @Override public void onBackPressed() {
     view.onBackPressed();
+  }
+
+  @Override public void onOpponentFinished(User opponent) {
+    view.game.onOpponentFinished(opponent);
   }
 }

--- a/2048/2048/src/main/java/com/appcoins/eskills2048/MainGame.java
+++ b/2048/2048/src/main/java/com/appcoins/eskills2048/MainGame.java
@@ -1,6 +1,7 @@
 package com.appcoins.eskills2048;
 
 import android.content.Context;
+import android.widget.Toast;
 import com.appcoins.eskills2048.activity.FinishGameActivity;
 import com.appcoins.eskills2048.model.LocalGameStatus;
 import com.appcoins.eskills2048.model.RoomResponse;
@@ -439,6 +440,7 @@ public class MainGame {
     try {
       List<User> opponents = roomResponse.getOpponents(viewModel.getWalletAddress());
       User opponent = userDetailsHelper.getNextOpponent(opponents);
+      viewModel.notify(opponent);
       opponentRank = opponent.getRank() + 1;
       opponentScore = opponent.getScore();
       opponentName = truncate(opponent.getUserName(), MAX_CHAR_DISPLAY_USERNAME);
@@ -454,5 +456,11 @@ public class MainGame {
     } else {
       return str;
     }
+  }
+
+  public void onOpponentFinished(User opponent) {
+    Toast.makeText(mView.getContext(), "Opponent " + opponent.getUserName() + " has finished.",
+        Toast.LENGTH_LONG)
+        .show();
   }
 }

--- a/2048/2048/src/main/java/com/appcoins/eskills2048/OpponentStatusListener.java
+++ b/2048/2048/src/main/java/com/appcoins/eskills2048/OpponentStatusListener.java
@@ -1,0 +1,7 @@
+package com.appcoins.eskills2048;
+
+import com.appcoins.eskills2048.model.User;
+
+public interface OpponentStatusListener {
+  void onOpponentFinished(User opponent);
+}

--- a/2048/2048/src/main/java/com/appcoins/eskills2048/activity/FinishGameActivity.java
+++ b/2048/2048/src/main/java/com/appcoins/eskills2048/activity/FinishGameActivity.java
@@ -38,7 +38,6 @@ import javax.inject.Inject;
   public static final String SESSION = "SESSION";
   public static final String WALLET_ADDRESS = "WALLET_ADDRESS";
   public static final String USER_SCORE = "USER_SCORE";
-  public static final String USER_STATUS = UserStatus.COMPLETED.toString();
   private static final Long GET_ROOM_PERIOD_SECONDS = 3L;
 
   private ActivityFinishGameBinding binding;
@@ -182,16 +181,6 @@ import javax.inject.Inject;
   }
 
   private void showErrorMessage(Throwable throwable) {
-    throwable.printStackTrace();
-    binding.lottieAnimation.setAnimation(R.raw.error_animation);
-    binding.lottieAnimation.playAnimation();
-    binding.animationDescriptionText.setText(getResources().getString(R.string.unknown_error));
-    binding.retryButton.setVisibility(View.VISIBLE);
-    binding.restartButton.setVisibility(View.GONE);
-    binding.restartButton.setEnabled(true);
-  }
-
-  private void showTimeUpMessage(Throwable throwable) {
     throwable.printStackTrace();
     binding.lottieAnimation.setAnimation(R.raw.error_animation);
     binding.lottieAnimation.playAnimation();

--- a/2048/2048/src/main/java/com/appcoins/eskills2048/usecase/NotifyOpponentFinishedUseCase.java
+++ b/2048/2048/src/main/java/com/appcoins/eskills2048/usecase/NotifyOpponentFinishedUseCase.java
@@ -5,9 +5,8 @@ import com.appcoins.eskills2048.model.User;
 import com.appcoins.eskills2048.model.UserStatus;
 import java.util.ArrayList;
 import java.util.List;
-import javax.inject.Singleton;
 
-@Singleton public class NotifyOpponentFinishedUseCase {
+public class NotifyOpponentFinishedUseCase {
   private final List<String> finishedOpponents = new ArrayList<>();
   private final OpponentStatusListener opponentStatusListener;
 

--- a/2048/2048/src/main/java/com/appcoins/eskills2048/usecase/NotifyOpponentFinishedUseCase.java
+++ b/2048/2048/src/main/java/com/appcoins/eskills2048/usecase/NotifyOpponentFinishedUseCase.java
@@ -1,0 +1,28 @@
+package com.appcoins.eskills2048.usecase;
+
+import com.appcoins.eskills2048.OpponentStatusListener;
+import com.appcoins.eskills2048.model.User;
+import com.appcoins.eskills2048.model.UserStatus;
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Singleton;
+
+@Singleton public class NotifyOpponentFinishedUseCase {
+  private final List<String> finishedOpponents = new ArrayList<>();
+  private final OpponentStatusListener opponentStatusListener;
+
+  public NotifyOpponentFinishedUseCase(OpponentStatusListener opponentStatusListener) {
+    this.opponentStatusListener = opponentStatusListener;
+  }
+
+  public void notify(User opponent) {
+    if (finishedOpponents.contains(opponent.getWalletAddress())) {
+      return;
+    }
+
+    if (opponent.getStatus() != UserStatus.PLAYING) {
+      opponentStatusListener.onOpponentFinished(opponent);
+      finishedOpponents.add(opponent.getWalletAddress());
+    }
+  }
+}

--- a/2048/2048/src/main/java/com/appcoins/eskills2048/vm/MainGameViewModel.java
+++ b/2048/2048/src/main/java/com/appcoins/eskills2048/vm/MainGameViewModel.java
@@ -3,7 +3,9 @@ package com.appcoins.eskills2048.vm;
 import com.appcoins.eskills2048.Tile;
 import com.appcoins.eskills2048.model.LocalGameStatus;
 import com.appcoins.eskills2048.model.RoomResponse;
+import com.appcoins.eskills2048.model.User;
 import com.appcoins.eskills2048.usecase.GetRoomUseCase;
+import com.appcoins.eskills2048.usecase.NotifyOpponentFinishedUseCase;
 import com.appcoins.eskills2048.usecase.SetFinalScoreUseCase;
 import com.appcoins.eskills2048.usecase.SetGameStatusLocallyUseCase;
 import com.appcoins.eskills2048.usecase.SetScoreUseCase;
@@ -16,15 +18,18 @@ public class MainGameViewModel {
   private final SetScoreUseCase setScoreUseCase;
   private final GetRoomUseCase getRoomUseCase;
   private final SetGameStatusLocallyUseCase setGameStatusLocallyUseCase;
+  private final NotifyOpponentFinishedUseCase notifyOpponentFinishedUseCase;
 
   public MainGameViewModel(SetScoreUseCase setScoreUseCase,
       SetFinalScoreUseCase setFinalScoreUseCase, MainGameViewModelData data,
-      GetRoomUseCase getRoomUseCase, SetGameStatusLocallyUseCase setGameStatusLocallyUseCase) {
+      GetRoomUseCase getRoomUseCase, SetGameStatusLocallyUseCase setGameStatusLocallyUseCase,
+      NotifyOpponentFinishedUseCase notifyOpponentFinishedUseCase) {
     this.setScoreUseCase = setScoreUseCase;
     this.setFinalScoreUseCase = setFinalScoreUseCase;
     this.data = data;
     this.getRoomUseCase = getRoomUseCase;
     this.setGameStatusLocallyUseCase = setGameStatusLocallyUseCase;
+    this.notifyOpponentFinishedUseCase = notifyOpponentFinishedUseCase;
   }
 
   public Single<RoomResponse> setFinalScore(long score) {
@@ -54,5 +59,9 @@ public class MainGameViewModel {
 
   public LocalGameStatus getGameStatus() {
     return data.getLocalGameStatus();
+  }
+
+  public void notify(User opponent) {
+    notifyOpponentFinishedUseCase.notify(opponent);
   }
 }

--- a/2048/2048/src/main/java/com/appcoins/eskills2048/vm/MainGameViewModel.java
+++ b/2048/2048/src/main/java/com/appcoins/eskills2048/vm/MainGameViewModel.java
@@ -61,4 +61,7 @@ public class MainGameViewModel {
     return data.getLocalGameStatus();
   }
 
+  public void notify(User opponent) {
+    notifyOpponentFinishedUseCase.notify(opponent);
+  }
 }


### PR DESCRIPTION
**What does this PR do?**

- Shows a toast when opponent finishes the match

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] 2048/2048/src/main/java/com/appcoins/eskills2048/MainActivity.java

**How should this be manually tested?**

Enter a new game with 2 devices. End game in one of them. On the other one you should see a Toast appearing saying your opponent has finished the game.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ESKL-130](https://aptoide.atlassian.net/browse/ESKL-130)

**Questions:**

N/A



**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass